### PR TITLE
環境設定スクリプトの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ GPU サーバーで簡単に利用できる Docker 環境です。
 #以下のファイルは、環境設定の際に一度だけ使う
 - /env.sh #環境変数を**ユーザ**が記入するファイル。のちの.shファイルで参照
 - /local.sh #VDIから実行する。
+- /proxy1.sh #local.sh によって proxy.sh の末尾に追加される
 - /setup.sh #local.shによってGPUサーバーにコピーされ、サーバー上で実行される
 - /test.sh #setup.shによって設定が正しく行われたか検証(GPUサーバ側)
 - /utils.sh #(未使用)

--- a/essential/local.sh
+++ b/essential/local.sh
@@ -29,10 +29,14 @@ then
             | sed -e 's/@/%40/g')@$proxy"
     fi
 
+    if [ ! -f proxy.sh ]
+    then
+        touch proxy.sh
+    fi
+    chmod 600 proxy.sh
     printf 'export ALL_PROXY="%s"\n' "$(printf '%s\n' "$proxy" \
         | sed -e 's/\(["$`\]\)/\\\1/g')" \
         | cat - proxy1.sh > proxy.sh
-    chmod 600 proxy.sh
 
     scp proxy.sh setup.sh test.sh better.sh "$USER_NAME@$GPU_URL:~"
 

--- a/essential/local.sh
+++ b/essential/local.sh
@@ -29,10 +29,8 @@ then
             | sed -e 's/@/%40/g')@$proxy"
     fi
 
-    proxy="$(printf '%s\n' "$proxy" \
-        | sed -e 's/\(["$`\]\)/\\\1/g')"
-
-    printf 'export ALL_PROXY="%s"\n' "$proxy" \
+    printf 'export ALL_PROXY="%s"\n' "$(printf '%s\n' "$proxy" \
+        | sed -e 's/\(["$`\]\)/\\\1/g')" \
         | cat - proxy1.sh > proxy.sh
     chmod 600 proxy.sh
 

--- a/essential/local.sh
+++ b/essential/local.sh
@@ -1,6 +1,9 @@
 . ./env.sh
 
-yes y |  ssh-keygen -t rsa -b 4096   
+if [ ! -f ~/.ssh/id_rsa ]
+then
+    ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -N ''
+fi
 ssh-copy-id $USER_NAME@$GPU_URL
 
 scp env.sh $USER_NAME@$GPU_URL:~/env.sh

--- a/essential/local.sh
+++ b/essential/local.sh
@@ -4,14 +4,44 @@ if [ ! -f ~/.ssh/id_rsa ]
 then
     ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -N ''
 fi
-ssh-copy-id $USER_NAME@$GPU_URL
 
-scp env.sh $USER_NAME@$GPU_URL:~/env.sh
-scp setup.sh $USER_NAME@$GPU_URL:~/setup.sh
-scp test.sh $USER_NAME@$GPU_URL:~/test.sh
-scp better.sh $USER_NAME@$GPU_URL:~/better.sh
+if ssh-copy-id $USER_NAME@$GPU_URL
+then
+    proxy="$PROXY_URL"
 
-ssh $USER_NAME@$GPU_URL pwd
-ssh $USER_NAME@$GPU_URL source env.sh
-ssh $USER_NAME@$GPU_URL "source env.sh; sh setup.sh"
-ssh $USER_NAME@$GPU_URL "source proxy.sh; sh test.sh"
+    if [ -n "$PORT" ]
+    then
+        proxy="$proxy:$PORT"
+    fi
+
+    if [ -n "$MS_USER_NAME" ]
+    then
+        proxy_user="$(printf '%s\n' "$MS_USER_NAME" \
+            | sed -e 's/:/%3a/g')"
+
+        if [ -n "$MS_USER_PASS" ]
+        then
+            proxy_user="$proxy_user:$(printf '%s\n' "$MS_USER_PASS" \
+                | sed -e 's/:/%3a/g')"
+        fi
+
+        proxy="$(printf '%s\n' "$proxy_user" \
+            | sed -e 's/@/%40/g')@$proxy"
+    fi
+
+    proxy="$(printf '%s\n' "$proxy" \
+        | sed -e 's/\(["$`\]\)/\\\1/g')"
+
+    printf 'export ALL_PROXY="%s"\n' "$proxy" \
+        | cat - proxy1.sh > proxy.sh
+    chmod 600 proxy.sh
+
+    scp proxy.sh setup.sh test.sh better.sh "$USER_NAME@$GPU_URL:~"
+
+    ssh "$USER_NAME@$GPU_URL" 'sh ~/setup.sh && source ~/.proxy.sh && sh ~/test.sh && rm ~/setup.sh ~/test.sh'
+else
+    echo 'Error: 環境変数とパスワードを確認してください'
+    echo "USER_NAME = $USER_NAME"
+    echo "GPU_URL   = $GPU_URL"
+    false
+fi

--- a/essential/proxy1.sh
+++ b/essential/proxy1.sh
@@ -1,0 +1,7 @@
+export HTTP_PROXY="$ALL_PROXY"
+export HTTPS_PROXY="$ALL_PROXY"
+export FTP_PROXY="$ALL_PROXY"
+export all_proxy="$ALL_PROXY"
+export http_proxy="$HTTP_PROXY"
+export https_proxy="$HTTPS_PROXY"
+export ftp_proxy="$FTP_PROXY"

--- a/essential/setup.sh
+++ b/essential/setup.sh
@@ -1,20 +1,11 @@
-proxy=$MS_USER_NAME:$MS_USER_PASS@$PROXY_URL:$PORT
-http_proxy="http://$proxy"
+test -f ~/proxy.sh && test -f ~/.proxy.sh || (
+    bash ~/proxy.sh && (
+        echo '[[ -f ~/.proxy.sh ]] && . ~/.proxy.sh' >> ~/.bashrc
 
+        test -f ~/.bash_profile || (echo '[[ -f ~/.bashrc ]] && . ~/.bashrc' > ~/.bash_profile)
+        echo '[[ -f ~/.proxy.sh ]] && . ~/.proxy.sh' >> ~/.bash_profile
 
-echo "
-proxy=$proxy
-http_proxy=$http_proxy
-https_proxy=$http_proxy
-ftp_proxy=$http_proxy
-socks_proxy=$http_proxy
-HTTP_PROXY=$http_proxy
-HTTPS_PROXY=$http_proxy
-
-export http_proxy https_proxy ftp_proxy socks_proxy HTTP_PROXY HTTPS_PROXY" > ~/proxy.sh
-
-echo 'source ~/proxy.sh' >> ~/.bash
-echo 'source ~/proxy.sh' >> ~/.bash_profile
-echo 'source ~/proxy.sh' >> ~/.zshrc
-
-echo "==SETUP COMPLETED=="
+        echo '[[ -f ~/.proxy.sh ]] && . ~/.proxy.sh' >> ~/.zshrc
+    )
+) && mv ~/proxy.sh ~/.proxy.sh \
+    && echo "==SETUP COMPLETED=="

--- a/essential/setup.sh
+++ b/essential/setup.sh
@@ -1,5 +1,5 @@
-test -f ~/proxy.sh && test -f ~/.proxy.sh || (
-    bash ~/proxy.sh && (
+test -f ~/proxy.sh && (
+    test -f ~/.proxy.sh || (
         echo '[[ -f ~/.proxy.sh ]] && . ~/.proxy.sh' >> ~/.bashrc
 
         test -f ~/.bash_profile || (echo '[[ -f ~/.bashrc ]] && . ~/.bashrc' > ~/.bash_profile)


### PR DESCRIPTION
## SSH 鍵の生成

SSH 鍵は `~/.ssh/id_rsa` に生成されます。
鍵がすでに存在する場合は上書きされません。

## SSH 鍵のコピー

`ssh-copy-id` に失敗すると、関連する環境変数を出力します。

## プロキシ

### 環境変数

`env.sh` で定義される環境変数の仕様を変更しました。

* `PROXY_URL`
    * 変更されません。
    * `http://` は挿入されません。
* `PORT`
    * 省略可
    * 変更されません。
* `MS_USER_NAME`
    * 省略可
    * 一部の文字が置換されます。
        * `:` -> `%3a`
        * `@` -> `%40`
* `MS_USER_PASS`
    * 省略可
    * `MS_USER_NAME` が省略された場合は無視されます。
    * 一部の文字が置換されます。
        * `:` -> `%3a`
        * `@` -> `%40`

これらの文字列は `proxy.sh` に書き込まれる前に Bash のダブルクォートの仕様に合わせて置換されます。

### スクリプト

`proxy.sh` は権限 `600` でローカルに作成され、リモートにコピーされます。

リモートに `~/.proxy.sh` が存在しない場合は `~/.bashrc`, `~/.bash_profile`, `~/.zshrc` に次の行が追加されます。

    [[ -f ~/.proxy.sh ]] && . ~/.proxy.sh

このとき `~/.bash_profile` が存在しない場合は、最初に次の行が書き込まれます。

    [[ -f ~/.bashrc ]] && . ~/.bashrc

最後に `~/proxy.sh` の名前を `~/.proxy.sh` に変更します。

コマンドが正常に終了すると `~/setup.sh` と `~/test.sh` が削除されます。
